### PR TITLE
Added LNLS data into global peak finding.

### DIFF
--- a/Constants.py
+++ b/Constants.py
@@ -7,10 +7,13 @@ npixY = 256
 # known inputs
 known_assemblies = ["A06-W0110","B06-W0125","B07-W0125","C04-W0110","D09-W0126","L04-W0125"]
 known_sources = ["Fe","Co","Cd","CuInXRF","Am","CoXRF","CrXRF","CuXRF","FeXRF","MnXRF","NiXRF","TiXRF","VXRF"]
-known_peaks = ["Fe","Co1","Cu","Co2","Cd","In","Am2","Am3"]
+known_peaks = ["Fe","Co1","CuXRF_CERN","Co2","Cd","InXRF","Am2","Am3","CoXRF","CrXRF","CuXRF_LNLS","FeXRF","MnXRF","NiXRF","TiXRF","VXRF"]
 
 CERN_sources = ["Fe","Co","Cd","CuInXRF","Am"]
 LNLS_sources = ["CoXRF","CrXRF","CuXRF","FeXRF","MnXRF","NiXRF","TiXRF","VXRF"]
+
+CERN_peaks = ["Fe","Co1","CuXRF_CERN","Co2","Cd","InXRF","Am2","Am3"]
+LNLS_peaks = ["CoXRF","CrXRF","CuXRF_LNLS","FeXRF","MnXRF","NiXRF","TiXRF","VXRF"]
 
 # peak energies in keV
 FePeakE = 5.899

--- a/calibrateKDEGlobal.py
+++ b/calibrateKDEGlobal.py
@@ -45,6 +45,10 @@ if peak not in C.known_peaks:
     print "choose from", C.known_peaks
     exit()
 
+if peak in C.LNLS_peaks and assembly != "A06-W0110":
+    print "Peak only available for assembly A06-W0110"
+    print "please reconsider input"
+    exit()
 
 def kde_scipy(x, x_grid, bandwidth=0.2, **kwargs):
     """Kernel Density Estimation with Scipy"""
@@ -68,7 +72,7 @@ def findMostLikelyTOT(assembly,peak,llim,ulim):
         rootfile = R.TFile("%s/%s/%s_SinglePixelCalibration/Am241_%s_spc.root"%(base,assembly,assembly_start,assembly))
     elif peak == "Cd":
         rootfile = R.TFile("%s/%s/%s_SinglePixelCalibration/Cd109_%s_spc.root"%(base,assembly,assembly_start,assembly))
-    elif peak == "Cu" or peak == "In":
+    elif peak == "CuXRF_CERN" or peak == "InXRF":
         if assembly == "B06-W0125":
             rootfile = R.TFile("%s/%s/%s_SinglePixelCalibration/Cu_In_%s_spc.root"%(base,assembly,assembly_start,assembly))
         else:
@@ -78,6 +82,22 @@ def findMostLikelyTOT(assembly,peak,llim,ulim):
             rootfile = R.TFile("%s/%s/%s_SinglePixelCalibration/Co57_%s_spc.root"%(base,assembly,assembly_start,assembly))
         else:
             rootfile = R.TFile("%s/%s/Co57_%s.root" %(base,assembly,assembly))
+    elif peak == "CoXRF":
+        rootfile = R.TFile("%s/LNLS_Analysis/SinglePixelAnalysis/root_files/%s-25V_CoXRF_CalibTree.root" %(base,assembly))
+    elif peak == "CrXRF":
+        rootfile = R.TFile("%s/LNLS_Analysis/SinglePixelAnalysis/root_files/%s-25V_CrXRF_CalibTree.root" %(base,assembly))
+    elif peak == "CuXRF_LNLS":
+        rootfile = R.TFile("%s/LNLS_Analysis/SinglePixelAnalysis/root_files/%s-25V_CuXRF_CalibTree.root" %(base,assembly))
+    elif peak == "FeXRF":
+        rootfile = R.TFile("%s/LNLS_Analysis/SinglePixelAnalysis/root_files/%s-25V_FeXRF_CalibTree.root" %(base,assembly))
+    elif peak == "MnXRF":
+        rootfile = R.TFile("%s/LNLS_Analysis/SinglePixelAnalysis/root_files/%s-25V_MnXRF_CalibTree.root" %(base,assembly))
+    elif peak == "NiXRF":
+        rootfile = R.TFile("%s/LNLS_Analysis/SinglePixelAnalysis/root_files/%s-25V_NiXRF_CalibTree.root" %(base,assembly))
+    elif peak == "TiXRF":
+        rootfile = R.TFile("%s/LNLS_Analysis/SinglePixelAnalysis/root_files/%s-25V_TiXRF_CalibTree.root" %(base,assembly))
+    elif peak == "VXRF":
+        rootfile = R.TFile("%s/LNLS_Analysis/SinglePixelAnalysis/root_files/%s-25V_VXRF_CalibTree.root" %(base,assembly))
 
     tree = rootfile.Get("pixels")
     print "got tree"
@@ -148,7 +168,7 @@ def findMostLikelyTOT(assembly,peak,llim,ulim):
     for item in ([ax.title, ax.xaxis.label, ax.yaxis.label] + ax.get_xticklabels() + ax.get_yticklabels()):
         item.set_fontsize(40)
     fig.tight_layout()
-    fig.savefig("plots/KDEPeaks/%s_%s_GlobalSpectrum.pdf" %(assembly,peak))
+    fig.savefig("plots/KDEPeaks/Global/%s_%s_GlobalSpectrum.pdf" %(assembly,peak))
 
     print "assembly", assembly, "maxtot", maxtot, "pm", uppersigma, lowersigma, "pm", step_size/2.
 
@@ -166,18 +186,26 @@ def getLimits(assembly,peak):
         if peak == "Am3": limits = [900,1500]
         if peak == "Am2": limits = [500,900]
         if peak == "Cd": limits = [400,800]
-        if peak == "Cu": limits = [0,500]
-        if peak == "In": limits = [500,1000]
+        if peak == "CuXRF_CERN": limits = [0,500]
+        if peak == "InXRF": limits = [500,1000]
         if peak == "Co1": limits = [0,300]
         if peak == "Co2": limits = [350,700]
+        if peak == "CoXRF": limits = [0,400]
+        if peak == "CrXRF": limits = [0,400]
+        if peak == "CuXRF_LNLS": limits = [0,400]
+        if peak == "FeXRF": limits = [0,400]
+        if peak == "MnXRF": limits = [0,400]
+        if peak == "NiXRF": limits = [0,400]
+        if peak == "TiXRF": limits = [0,400]
+        if peak == "VXRF": limits = [0,400]
 
     if assembly == "B06-W0125":
         if peak == "Fe": limits = [0,700]
         if peak == "Am3": limits = [1800,2800]
         if peak == "Am2": limits = [900,1800]
         if peak == "Cd": limits = [800,1700]
-        if peak == "Cu": limits = [0,700]
-        if peak == "In": limits = [800,1700]
+        if peak == "CuXRF_CERN": limits = [0,700]
+        if peak == "InXRF": limits = [800,1700]
         if peak == "Co1": limits = [0,600]
         if peak == "Co2": limits = [600,1100]
 
@@ -186,8 +214,8 @@ def getLimits(assembly,peak):
         if peak == "Am3": limits = [900,1500]
         if peak == "Am2": limits = [550,1000]
         if peak == "Cd": limits = [500,900]
-        if peak == "Cu": limits = [0,400]
-        if peak == "In": limits = [400,1000]
+        if peak == "CuXRF_CERN": limits = [0,400]
+        if peak == "InXRF": limits = [400,1000]
         if peak == "Co1": limits = [0,400]
         if peak == "Co2": limits = [350,600]
 
@@ -196,8 +224,8 @@ def getLimits(assembly,peak):
         if peak == "Am3": limits = [900,1400]
         if peak == "Am2": limits = [500,900]
         if peak == "Cd": limits = [400,800]
-        if peak == "Cu": limits = [0,500]
-        if peak == "In": limits = [500,700]
+        if peak == "CuXRF_CERN": limits = [0,500]
+        if peak == "InXRF": limits = [500,700]
         if peak == "Co1": limits = [0,400]
         if peak == "Co2": limits = [350,600]
 
@@ -206,8 +234,8 @@ def getLimits(assembly,peak):
         if peak == "Am3": limits = [1200,1800]
         if peak == "Am2": limits = [600,1200]
         if peak == "Cd": limits = [600,1200]
-        if peak == "Cu": limits = [0,600]
-        if peak == "In": limits = [600,1100]
+        if peak == "CuXRF_CERN": limits = [0,600]
+        if peak == "InXRF": limits = [600,1100]
         if peak == "Co1": limits = [0,500]
         if peak == "Co2": limits = [500,800]
 
@@ -216,8 +244,8 @@ def getLimits(assembly,peak):
         if peak == "Am3": limits = [1000,2000]
         if peak == "Am2": limits = [600,1000]
         if peak == "Cd": limits = [500,1100]
-        if peak == "Cu": limits = [0,600]
-        if peak == "In": limits = [600,1200]
+        if peak == "CuXRF_CERN": limits = [0,600]
+        if peak == "InXRF": limits = [600,1200]
         if peak == "Co1": limits = [0,400]
         if peak == "Co2": limits = [400,700]
 


### PR DESCRIPTION
In Constants.py:
- added LNLS peaks to known peaks
- also created CERN_peaks and LNLS_peaks
- be careful - CuXRF data recorded at CERN and LNLS!

In calibrateKDEGlobal.py:
- load LNLS data
- check LNLS data only with A06-W0110
- decided to put plots into a global directory, to stop them being
  mixed up with all the pixel plots
